### PR TITLE
Add type filtering option to geocoding request

### DIFF
--- a/geocoding_api.go
+++ b/geocoding_api.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 var _ = log.Print
@@ -51,8 +52,11 @@ func (api *GeocodingAPI) buildURL(req *QueryByAddressRequest) (string, error) {
 		q.Set("proximity", fmt.Sprintf("%.3f,%.3f", req.Proximity.Longitude, req.Proximity.Latitude))
 	}
 
-	u.RawQuery = q.Encode()
+	if len(req.Types) > 0 {
+		q.Set("types", strings.Join(req.Types, ","))
+	}
 
+	u.RawQuery = q.Encode()
 	return u.String(), nil
 }
 
@@ -84,6 +88,8 @@ type QueryByAddressRequest struct {
 	Query string
 	// Proximity is a set of coordinates
 	Proximity *Coordinate
+	// Types are filters on the granularity of results to return, e.g. region, locality, poi
+	Types []string
 }
 
 // NewQueryByAddressRequest creates a new QueryByAddressRequest.


### PR DESCRIPTION
For testing, note that we cannot check that a feature's
geometry type is "Region" to verify that the result
is a region. This is because queries like India resolve to "Point".
